### PR TITLE
close #6 BaseActivity 만들기

### DIFF
--- a/app/src/main/java/com/hbs/worldcup/core/BaseActivity.kt
+++ b/app/src/main/java/com/hbs/worldcup/core/BaseActivity.kt
@@ -1,0 +1,24 @@
+package com.hbs.worldcup.core
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.databinding.DataBindingUtil
+import androidx.databinding.ViewDataBinding
+import com.hbs.domain.model.core.ActivityInitializer
+
+abstract class BaseActivity<B : ViewDataBinding> : AppCompatActivity() {
+    lateinit var binding: B
+    abstract fun getActivityInitializer(): ActivityInitializer
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        bindActivity()
+    }
+
+    private fun bindActivity() = getActivityInitializer()
+        .takeIf { it.isUseTransition }
+        ?.let {
+            binding = DataBindingUtil.setContentView(this, it.layoutId)
+            binding.lifecycleOwner = this
+        }
+}

--- a/app/src/main/java/com/hbs/worldcup/ui/quizlist/QuizListActivity.kt
+++ b/app/src/main/java/com/hbs/worldcup/ui/quizlist/QuizListActivity.kt
@@ -2,19 +2,24 @@ package com.hbs.worldcup.ui.quizlist
 
 import android.os.Bundle
 import androidx.activity.viewModels
-import androidx.appcompat.app.AppCompatActivity
+import com.hbs.domain.model.core.ActivityInitializer
+import com.hbs.worldcup.R
+import com.hbs.worldcup.core.BaseActivity
 import com.hbs.worldcup.databinding.QuizListActivityBinding
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class QuizListActivity : AppCompatActivity() {
+class QuizListActivity : BaseActivity<QuizListActivityBinding>() {
     private val quizListViewModel by viewModels<QuizListViewModel>()
+
+    override fun getActivityInitializer() = ActivityInitializer(R.layout.quiz_list_activity, false)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val binding = QuizListActivityBinding.inflate(layoutInflater)
-        setContentView(binding.root)
-        binding.lifecycleOwner = this
+        bindViewModel()
+    }
+
+    private fun bindViewModel() {
         binding.viewModel = quizListViewModel
     }
 }

--- a/domain/src/main/java/com/hbs/domain/model/core/ActivityInitializer.kt
+++ b/domain/src/main/java/com/hbs/domain/model/core/ActivityInitializer.kt
@@ -1,0 +1,3 @@
+package com.hbs.domain.model.core
+
+data class ActivityInitializer(val layoutId:Int, val isUseTransition:Boolean)


### PR DESCRIPTION
### 작업 내용
- [x] Activity에 대한 정보를 담고 있는 ActivityInitializer 모델을 추가
- [x] BaseActivity를 추가

### 코멘트
- BaseActivity를 상속받게 되면 `getActivityInitializer()`을 통해서 액티비티에 대한 정보(레이아웃 아이디, 트랜잭션 사용 여부)를 담은 모델을 만들게 되면, BaseActivity가 레이아웃을 바인딩하고, 뷰모델을 셋팅하는 로직을 공통화 시켰습니다.